### PR TITLE
Removed redundant line from card

### DIFF
--- a/assignments/user_stories.md
+++ b/assignments/user_stories.md
@@ -264,7 +264,7 @@ _Spring 2022_
 - How are prior students encouraged to share information they have on their
   experience taking a course?
 - How are students able to discern the information they receive is reliable?
-- 
+  
 #### Confirmation
 
 - The service encourages users to complete a profile that includes their
@@ -356,7 +356,7 @@ _Spring 2022_
 
 - What are some of the traditions/experiences that are unique to UF?
 - How can I meet people with similar interests and become involved?
-- 
+
 #### Confirmation
 
 - Users have access to a forum where they can share information on traditions

--- a/assignments/user_stories.md
+++ b/assignments/user_stories.md
@@ -399,7 +399,6 @@ _Spring 2022_
 | As a graduate who has entered the career field, I    |
 | want to network with other alumni so that I can form |
 | business partnerships with my fellow alumni.         |
-| mentor to a younger Gator generation.                |
 
 #### Conversation
 


### PR DESCRIPTION
This is my mistake, I left an extra line in the 'Network with alumni' card when I copied the markdown tables over from a formatter.